### PR TITLE
Update for video.js 6

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -64,7 +64,7 @@ const dimensionsCheck = function() {
     let layoutDefinition = layouter.options.layoutMap[layouter.currentLayout_];
 
     if (layoutDefinition.layoutClassName !== 'defaults') {
-      videojs.addClass(el, layoutDefinition.layoutClassName);
+      (videojs.dom || videojs).addClass(el, layoutDefinition.layoutClassName);
     }
     layouter.options.layoutMap.forEach(function(element, index) {
       if (index !== layouter.currentLayout_ && element.layoutClassName !== 'defaults') {
@@ -255,6 +255,6 @@ const responsiveLayout = function(options) {
 };
 
 // Register the plugin with video.js.
-videojs.plugin('responsiveLayout', responsiveLayout);
+(videojs.registerPlugin || videojs.plugin)('responsiveLayout', responsiveLayout);
 
 export default responsiveLayout;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -180,11 +180,12 @@ class Layouter {
     let controlBarWidth = 0;
     let cbElements = this.el.querySelectorAll('.vjs-control-bar > *');
 
-    Array.from(cbElements).forEach(function(el) {
+    for (var i = 0; i < cbElements.length; i++) {
+      var el = cbElements[i];
       if (isElementVisible(el)) {
         controlBarWidth += getElementOuterWidth(el);
       }
-    });
+    }
     return controlBarWidth;
   }
 


### PR DESCRIPTION
Use videojs.dom.addClass and videojs.registerPlugin as necessary
if on video.js 6, to avoid warnings about deprecated methods.